### PR TITLE
change: exclude embedded sim notebook from tests

### DIFF
--- a/test/notebook_tests/test_notebooks.py
+++ b/test/notebook_tests/test_notebooks.py
@@ -31,6 +31,7 @@ EXCLUDED_NOTEBOOKS = [
     "bring_your_own_container.ipynb",
     "qnspsa_with_embedded_simulator.ipynb",
     "Parallelize_training_for_QML.ipynb",
+    "Embedded_simulators_in_Braket_Jobs.ipynb",
 ]
 
 


### PR DESCRIPTION
Temporarily excluding embedded sim notebook from tests since ml.2xlarge instances getting stuck for jobs until sagemaker limits are increased.